### PR TITLE
Federation for custom emojis

### DIFF
--- a/crates/api/src/site/leave_admin.rs
+++ b/crates/api/src/site/leave_admin.rs
@@ -77,6 +77,7 @@ impl Perform for LeaveAdmin {
       all_languages,
       discussion_languages,
       taglines,
+      custom_emojis: None,
     })
   }
 }

--- a/crates/api_common/src/custom_emoji.rs
+++ b/crates/api_common/src/custom_emoji.rs
@@ -1,0 +1,41 @@
+use crate::sensitive::Sensitive;
+use lemmy_db_views::structs::CustomEmojiView;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateCustomEmoji {
+  pub category: String,
+  pub shortcode: String,
+  pub image_url: Url,
+  pub alt_text: String,
+  pub keywords: Vec<String>,
+  pub auth: Sensitive<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EditCustomEmoji {
+  pub id: i32,
+  pub category: String,
+  pub image_url: Url,
+  pub alt_text: String,
+  pub keywords: Vec<String>,
+  pub auth: Sensitive<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct DeleteCustomEmoji {
+  pub id: i32,
+  pub auth: Sensitive<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DeleteCustomEmojiResponse {
+  pub id: i32,
+  pub success: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CustomEmojiResponse {
+  pub custom_emoji: CustomEmojiView,
+}

--- a/crates/api_common/src/lib.rs
+++ b/crates/api_common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod comment;
 pub mod community;
 #[cfg(feature = "full")]
 pub mod context;
+pub mod custom_emoji;
 pub mod person;
 pub mod post;
 pub mod private_message;

--- a/crates/api_common/src/site.rs
+++ b/crates/api_common/src/site.rs
@@ -9,6 +9,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{
   CommentView,
+  CustomEmojiView,
   LocalUserSettingsView,
   PostView,
   RegistrationApplicationView,
@@ -221,6 +222,7 @@ pub struct GetSiteResponse {
   pub all_languages: Vec<Language>,
   pub discussion_languages: Vec<LanguageId>,
   pub taglines: Option<Vec<Tagline>>,
+  pub custom_emojis: Option<Vec<CustomEmojiView>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/api_common/src/websocket/mod.rs
+++ b/crates/api_common/src/websocket/mod.rs
@@ -117,6 +117,10 @@ pub enum UserOperationCrud {
   GetPrivateMessages,
   EditPrivateMessage,
   DeletePrivateMessage,
+  //Emojis
+  CreateCustomEmoji,
+  EditCustomEmoji,
+  DeleteCustomEmoji,
 }
 
 #[derive(EnumString, Display, Debug, Clone)]

--- a/crates/api_crud/src/custom_emoji/create.rs
+++ b/crates/api_crud/src/custom_emoji/create.rs
@@ -1,0 +1,53 @@
+use crate::PerformCrud;
+use actix_web::web::Data;
+use lemmy_api_common::{
+  context::LemmyContext,
+  custom_emoji::{CreateCustomEmoji, CustomEmojiResponse},
+  utils::{get_local_user_view_from_jwt, is_admin},
+};
+use lemmy_db_schema::source::{
+  custom_emoji::{CustomEmoji, CustomEmojiInsertForm},
+  custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+  local_site::LocalSite,
+};
+use lemmy_db_views::structs::CustomEmojiView;
+use lemmy_utils::{error::LemmyError, ConnectionId};
+
+#[async_trait::async_trait(?Send)]
+impl PerformCrud for CreateCustomEmoji {
+  type Response = CustomEmojiResponse;
+
+  #[tracing::instrument(skip(self, context, _websocket_id))]
+  async fn perform(
+    &self,
+    context: &Data<LemmyContext>,
+    _websocket_id: Option<ConnectionId>,
+  ) -> Result<CustomEmojiResponse, LemmyError> {
+    let data: &CreateCustomEmoji = self;
+    let local_user_view =
+      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+
+    let local_site = LocalSite::read(context.pool()).await?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
+
+    let emoji_form = CustomEmojiInsertForm::builder()
+      .local_site_id(local_site.id)
+      .shortcode(data.shortcode.to_lowercase().trim().to_string())
+      .alt_text(data.alt_text.to_string())
+      .category(data.category.to_string())
+      .image_url(data.clone().image_url.into())
+      .build();
+    let emoji = CustomEmoji::create(context.pool(), &emoji_form).await?;
+    for keyword in &data.keywords {
+      let keyword_form = CustomEmojiKeywordInsertForm::builder()
+        .custom_emoji_id(emoji.id)
+        .keyword(keyword.to_lowercase().trim().to_string())
+        .build();
+
+      CustomEmojiKeyword::create(context.pool(), &keyword_form).await?;
+    }
+    let view = CustomEmojiView::get(context.pool(), emoji.id).await?;
+    Ok(CustomEmojiResponse { custom_emoji: view })
+  }
+}

--- a/crates/api_crud/src/custom_emoji/delete.rs
+++ b/crates/api_crud/src/custom_emoji/delete.rs
@@ -1,0 +1,33 @@
+use crate::PerformCrud;
+use actix_web::web::Data;
+use lemmy_api_common::{
+  context::LemmyContext,
+  custom_emoji::{DeleteCustomEmoji, DeleteCustomEmojiResponse},
+  utils::{get_local_user_view_from_jwt, is_admin},
+};
+use lemmy_db_schema::source::custom_emoji::CustomEmoji;
+use lemmy_utils::{error::LemmyError, ConnectionId};
+
+#[async_trait::async_trait(?Send)]
+impl PerformCrud for DeleteCustomEmoji {
+  type Response = DeleteCustomEmojiResponse;
+
+  #[tracing::instrument(skip(self, context, _websocket_id))]
+  async fn perform(
+    &self,
+    context: &Data<LemmyContext>,
+    _websocket_id: Option<ConnectionId>,
+  ) -> Result<DeleteCustomEmojiResponse, LemmyError> {
+    let data: &DeleteCustomEmoji = self;
+    let local_user_view =
+      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
+    CustomEmoji::delete(context.pool(), data.id).await?;
+    Ok(DeleteCustomEmojiResponse {
+      id: data.id,
+      success: true,
+    })
+  }
+}

--- a/crates/api_crud/src/custom_emoji/mod.rs
+++ b/crates/api_crud/src/custom_emoji/mod.rs
@@ -1,0 +1,3 @@
+mod create;
+mod delete;
+mod update;

--- a/crates/api_crud/src/custom_emoji/update.rs
+++ b/crates/api_crud/src/custom_emoji/update.rs
@@ -1,0 +1,53 @@
+use crate::PerformCrud;
+use actix_web::web::Data;
+use lemmy_api_common::{
+  context::LemmyContext,
+  custom_emoji::{CustomEmojiResponse, EditCustomEmoji},
+  utils::{get_local_user_view_from_jwt, is_admin},
+};
+use lemmy_db_schema::source::{
+  custom_emoji::{CustomEmoji, CustomEmojiUpdateForm},
+  custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+  local_site::LocalSite,
+};
+use lemmy_db_views::structs::CustomEmojiView;
+use lemmy_utils::{error::LemmyError, ConnectionId};
+
+#[async_trait::async_trait(?Send)]
+impl PerformCrud for EditCustomEmoji {
+  type Response = CustomEmojiResponse;
+
+  #[tracing::instrument(skip(self, context, _websocket_id))]
+  async fn perform(
+    &self,
+    context: &Data<LemmyContext>,
+    _websocket_id: Option<ConnectionId>,
+  ) -> Result<CustomEmojiResponse, LemmyError> {
+    let data: &EditCustomEmoji = self;
+    let local_user_view =
+      get_local_user_view_from_jwt(&data.auth, context.pool(), context.secret()).await?;
+
+    let local_site = LocalSite::read(context.pool()).await?;
+    // Make sure user is an admin
+    is_admin(&local_user_view)?;
+
+    let emoji_form = CustomEmojiUpdateForm::builder()
+      .local_site_id(local_site.id)
+      .alt_text(data.alt_text.to_string())
+      .category(data.category.to_string())
+      .image_url(data.clone().image_url.into())
+      .build();
+    let emoji = CustomEmoji::update(context.pool(), data.id, &emoji_form).await?;
+    CustomEmojiKeyword::delete(context.pool(), data.id).await?;
+    for keyword in &data.keywords {
+      let keyword_form = CustomEmojiKeywordInsertForm::builder()
+        .custom_emoji_id(emoji.id)
+        .keyword(keyword.to_lowercase().trim().to_string())
+        .build();
+
+      CustomEmojiKeyword::create(context.pool(), &keyword_form).await?;
+    }
+    let view = CustomEmojiView::get(context.pool(), emoji.id).await?;
+    Ok(CustomEmojiResponse { custom_emoji: view })
+  }
+}

--- a/crates/api_crud/src/lib.rs
+++ b/crates/api_crud/src/lib.rs
@@ -5,6 +5,7 @@ use lemmy_utils::{error::LemmyError, ConnectionId};
 
 mod comment;
 mod community;
+mod custom_emoji;
 mod post;
 mod private_message;
 mod site;

--- a/crates/api_crud/src/site/read.rs
+++ b/crates/api_crud/src/site/read.rs
@@ -10,7 +10,7 @@ use lemmy_db_schema::source::{
   language::Language,
   tagline::Tagline,
 };
-use lemmy_db_views::structs::SiteView;
+use lemmy_db_views::structs::{CustomEmojiView, SiteView};
 use lemmy_db_views_actor::structs::{
   CommunityBlockView,
   CommunityFollowerView,
@@ -90,6 +90,9 @@ impl PerformCrud for GetSite {
     let discussion_languages = SiteLanguage::read_local(context.pool()).await?;
     let taglines_res = Tagline::get_all(context.pool(), site_view.local_site.id).await?;
     let taglines = (!taglines_res.is_empty()).then_some(taglines_res);
+    let custom_emojis_res =
+      CustomEmojiView::get_all(context.pool(), site_view.local_site.id).await?;
+    let custom_emojis = (!custom_emojis_res.is_empty()).then_some(custom_emojis_res);
 
     Ok(GetSiteResponse {
       site_view,
@@ -101,6 +104,7 @@ impl PerformCrud for GetSite {
       all_languages,
       discussion_languages,
       taglines,
+      custom_emojis,
     })
   }
 }

--- a/crates/apub/assets/lemmy/objects/page.json
+++ b/crates/apub/assets/lemmy/objects/page.json
@@ -8,10 +8,10 @@
   ],
   "audience": "https://enterprise.lemmy.ml/c/tenforward",
   "name": "Post title",
-  "content": "<p>This is a post in the /c/tenforward community</p>\n",
+  "content": "<p>This is a post in the /c/tenforward community :kappa:</p>\n",
   "mediaType": "text/html",
   "source": {
-    "content": "This is a post in the /c/tenforward community",
+    "content": "This is a post in the /c/tenforward community :kappa:",
     "mediaType": "text/markdown"
   },
   "attachment": [
@@ -31,5 +31,16 @@
     "identifier": "fr",
     "name": "Français"
   },
+  "tag": [
+    {
+      "id": "https://example.com/emoji/123",
+      "type": "Emoji",
+      "name": ":kappa:",
+      "icon": {
+        "type": "Image",
+        "url": "https://example.com/files/kappa.png"
+      }
+    }
+  ],
   "published": "2021-02-26T12:35:34.292626+00:00"
 }

--- a/crates/apub/src/activities/create_or_update/comment.rs
+++ b/crates/apub/src/activities/create_or_update/comment.rs
@@ -1,5 +1,5 @@
 use crate::{
-  activities::{
+    activities::{
     check_community_deleted_or_removed,
     community::send_activity_in_community,
     create_or_update::get_comment_notif_recipients,
@@ -7,16 +7,16 @@ use crate::{
     verify_is_public,
     verify_person_in_community,
   },
-  activity_lists::AnnouncableActivities,
-  local_instance,
-  mentions::MentionOrValue,
-  objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
-  protocol::{
+    activity_lists::AnnouncableActivities,
+    local_instance,
+    mentions::NoteTags,
+    objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson},
+    protocol::{
     activities::{create_or_update::note::CreateOrUpdateNote, CreateOrUpdateType},
     InCommunity,
   },
-  ActorType,
-  SendActivity,
+    ActorType,
+    SendActivity,
 };
 use activitypub_federation::{
   core::object_id::ObjectId,
@@ -118,7 +118,7 @@ impl CreateOrUpdateNote {
       .tag
       .iter()
       .filter_map(|t| {
-        if let MentionOrValue::Mention(t) = t {
+        if let NoteTags::Mention(t) = t {
           Some(t)
         } else {
           None

--- a/crates/apub/src/activities/unfederated.rs
+++ b/crates/apub/src/activities/unfederated.rs
@@ -20,6 +20,13 @@ use lemmy_api_common::{
     ListCommunitiesResponse,
     TransferCommunity,
   },
+  custom_emoji::{
+    CreateCustomEmoji,
+    CustomEmojiResponse,
+    DeleteCustomEmoji,
+    DeleteCustomEmojiResponse,
+    EditCustomEmoji,
+  },
   person::{
     AddAdmin,
     AddAdminResponse,
@@ -348,4 +355,16 @@ impl SendActivity for ListCommentReports {
 
 impl SendActivity for ResolveCommentReport {
   type Response = CommentReportResponse;
+}
+
+impl SendActivity for CreateCustomEmoji {
+  type Response = CustomEmojiResponse;
+}
+
+impl SendActivity for EditCustomEmoji {
+  type Response = CustomEmojiResponse;
+}
+
+impl SendActivity for DeleteCustomEmoji {
+  type Response = DeleteCustomEmojiResponse;
 }

--- a/crates/apub/src/mentions.rs
+++ b/crates/apub/src/mentions.rs
@@ -18,12 +18,14 @@ use lemmy_utils::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use url::Url;
+use crate::protocol::objects::Emoji;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum MentionOrValue {
+pub enum NoteTags {
   Mention(Mention),
   Value(Value),
+  Emoji(Emoji)
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -36,7 +38,7 @@ pub struct Mention {
 
 pub struct MentionsAndAddresses {
   pub ccs: Vec<Url>,
-  pub tags: Vec<MentionOrValue>,
+  pub tags: Vec<NoteTags>,
 }
 
 /// This takes a comment, and builds a list of to_addresses, inboxes,
@@ -88,7 +90,7 @@ pub async fn collect_non_local_mentions(
     }
   }
 
-  let tags = tags.into_iter().map(MentionOrValue::Mention).collect();
+  let tags = tags.into_iter().map(NoteTags::Mention).collect();
   Ok(MentionsAndAddresses {
     ccs: addressed_ccs,
     tags,

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -123,6 +123,7 @@ impl ApubObject for ApubComment {
       in_reply_to,
       published: Some(convert_datetime(self.published)),
       updated: self.updated.map(convert_datetime),
+      // TODO: write comment emojis here
       tag: maa.tags,
       distinguished: Some(self.distinguished),
       language,
@@ -181,6 +182,8 @@ impl ApubObject for ApubComment {
     let slur_regex = &local_site_opt_to_slur_regex(&local_site);
     let content_slurs_removed = remove_slurs(&content, slur_regex);
     let language_id = LanguageTag::to_language_id_single(note.language, context.pool()).await?;
+
+    // TODO: read emojis from tag and write to db
 
     let form = CommentInsertForm {
       creator_id: creator.id,

--- a/crates/apub/src/objects/post.rs
+++ b/crates/apub/src/objects/post.rs
@@ -121,6 +121,8 @@ impl ApubObject for ApubPost {
       published: Some(convert_datetime(self.published)),
       updated: self.updated.map(convert_datetime),
       audience: Some(ObjectId::new(community.actor_id)),
+      // TODO: write emojis which are used in post
+      tag: vec![]
     };
     Ok(page)
   }
@@ -195,6 +197,8 @@ impl ApubObject for ApubPost {
         read_from_string_or_source_opt(&page.content, &page.media_type, &page.source)
           .map(|s| remove_slurs(&s, slur_regex));
       let language_id = LanguageTag::to_language_id_single(page.language, context.pool()).await?;
+
+      // TODO: read emojis which are used in post from page.tag, and write them to db
 
       PostInsertForm {
         name: page.name.clone(),
@@ -295,7 +299,7 @@ mod tests {
     assert_eq!(post.ap_id, url.into());
     assert_eq!(post.name, "Post title");
     assert!(post.body.is_some());
-    assert_eq!(post.body.as_ref().unwrap().len(), 45);
+    assert_eq!(post.body.as_ref().unwrap().len(), 53);
     assert!(!post.locked);
     assert!(post.featured_community);
     assert_eq!(request_counter, 0);

--- a/crates/apub/src/protocol/activities/create_or_update/note.rs
+++ b/crates/apub/src/protocol/activities/create_or_update/note.rs
@@ -1,9 +1,9 @@
 use crate::{
-  activities::verify_community_matches,
-  local_instance,
-  mentions::MentionOrValue,
-  objects::{community::ApubCommunity, person::ApubPerson},
-  protocol::{activities::CreateOrUpdateType, objects::note::Note, InCommunity},
+    activities::verify_community_matches,
+    local_instance,
+    mentions::NoteTags,
+    objects::{community::ApubCommunity, person::ApubPerson},
+    protocol::{activities::CreateOrUpdateType, objects::note::Note, InCommunity},
 };
 use activitypub_federation::{core::object_id::ObjectId, deser::helpers::deserialize_one_or_many};
 use lemmy_api_common::context::LemmyContext;
@@ -22,7 +22,7 @@ pub struct CreateOrUpdateNote {
   #[serde(deserialize_with = "deserialize_one_or_many")]
   pub(crate) cc: Vec<Url>,
   #[serde(default)]
-  pub(crate) tag: Vec<MentionOrValue>,
+  pub(crate) tag: Vec<NoteTags>,
   #[serde(rename = "type")]
   pub(crate) kind: CreateOrUpdateType,
   pub(crate) id: Url,

--- a/crates/apub/src/protocol/objects/mod.rs
+++ b/crates/apub/src/protocol/objects/mod.rs
@@ -2,6 +2,7 @@ use lemmy_db_schema::{newtypes::LanguageId, source::language::Language, utils::D
 use lemmy_utils::error::LemmyError;
 use serde::{Deserialize, Serialize};
 use url::Url;
+use crate::protocol::objects::page::Image;
 
 pub(crate) mod chat_message;
 pub(crate) mod group;
@@ -86,6 +87,21 @@ impl LanguageTag {
 
     Ok(language_ids)
   }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum EmojiType {
+  Emoji
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Emoji {
+  id: Url,
+  #[serde(rename = "type")]
+  kind: EmojiType,
+  name: String,
+  icon: Image
 }
 
 #[cfg(test)]

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -2,7 +2,7 @@ use crate::{
   activities::verify_community_matches,
   fetcher::post_or_comment::PostOrComment,
   local_instance,
-  mentions::MentionOrValue,
+  mentions::NoteTags,
   objects::{comment::ApubComment, community::ApubCommunity, person::ApubPerson, post::ApubPost},
   protocol::{objects::LanguageTag, InCommunity, Source},
 };
@@ -46,7 +46,7 @@ pub struct Note {
   pub(crate) published: Option<DateTime<FixedOffset>>,
   pub(crate) updated: Option<DateTime<FixedOffset>>,
   #[serde(default)]
-  pub(crate) tag: Vec<MentionOrValue>,
+  pub(crate) tag: Vec<NoteTags>,
   // lemmy extension
   pub(crate) distinguished: Option<bool>,
   pub(crate) language: Option<LanguageTag>,

--- a/crates/apub/src/protocol/objects/page.rs
+++ b/crates/apub/src/protocol/objects/page.rs
@@ -26,6 +26,7 @@ use lemmy_utils::error::LemmyError;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use url::Url;
+use crate::protocol::objects::Emoji;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum PageType {
@@ -66,6 +67,8 @@ pub struct Page {
   pub(crate) updated: Option<DateTime<FixedOffset>>,
   pub(crate) language: Option<LanguageTag>,
   pub(crate) audience: Option<ObjectId<ApubCommunity>>,
+  #[serde(deserialize_with = "deserialize_skip_error", default)]
+  pub(crate) tag: Vec<Emoji>
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/db_schema/src/impls/custom_emoji.rs
+++ b/crates/db_schema/src/impls/custom_emoji.rs
@@ -1,0 +1,56 @@
+use crate::{
+  schema::{
+    custom_emoji::dsl::custom_emoji,
+    custom_emoji_keyword::dsl::{custom_emoji_id, custom_emoji_keyword},
+  },
+  source::{
+    custom_emoji::{CustomEmoji, CustomEmojiInsertForm, CustomEmojiUpdateForm},
+    custom_emoji_keyword::{CustomEmojiKeyword, CustomEmojiKeywordInsertForm},
+  },
+  utils::{get_conn, DbPool},
+};
+use diesel::{dsl::insert_into, result::Error, ExpressionMethods, QueryDsl};
+use diesel_async::RunQueryDsl;
+
+impl CustomEmoji {
+  pub async fn create(pool: &DbPool, form: &CustomEmojiInsertForm) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    insert_into(custom_emoji)
+      .values(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+  pub async fn update(
+    pool: &DbPool,
+    emoji_id: i32,
+    form: &CustomEmojiUpdateForm,
+  ) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::update(custom_emoji.find(emoji_id))
+      .set(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+  pub async fn delete(pool: &DbPool, emoji_id: i32) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::delete(custom_emoji.find(emoji_id))
+      .execute(conn)
+      .await
+  }
+}
+
+impl CustomEmojiKeyword {
+  pub async fn create(pool: &DbPool, form: &CustomEmojiKeywordInsertForm) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    insert_into(custom_emoji_keyword)
+      .values(form)
+      .get_result::<Self>(conn)
+      .await
+  }
+  pub async fn delete(pool: &DbPool, emoji_id: i32) -> Result<usize, Error> {
+    let conn = &mut get_conn(pool).await?;
+    diesel::delete(custom_emoji_keyword.filter(custom_emoji_id.eq(emoji_id)))
+      .execute(conn)
+      .await
+  }
+}

--- a/crates/db_schema/src/impls/mod.rs
+++ b/crates/db_schema/src/impls/mod.rs
@@ -5,6 +5,7 @@ pub mod comment_reply;
 pub mod comment_report;
 pub mod community;
 pub mod community_block;
+pub mod custom_emoji;
 pub mod email_verification;
 pub mod federation_allowlist;
 pub mod federation_blocklist;

--- a/crates/db_schema/src/schema.rs
+++ b/crates/db_schema/src/schema.rs
@@ -742,6 +742,27 @@ table! {
     }
 }
 
+table! {
+  custom_emoji (id) {
+    id -> Int4,
+    local_site_id -> Int4,
+    shortcode -> Varchar,
+    image_url -> Text,
+    alt_text -> Text,
+    category -> Text,
+    published -> Timestamp,
+    updated -> Nullable<Timestamp>,
+    }
+}
+
+table! {
+  custom_emoji_keyword (id) {
+    id -> Int4,
+    custom_emoji_id -> Int4,
+    keyword -> Varchar,
+    }
+}
+
 joinable!(person_block -> person (person_id));
 
 joinable!(comment -> person (creator_id));
@@ -827,6 +848,8 @@ joinable!(federation_blocklist -> instance (instance_id));
 joinable!(local_site -> site (site_id));
 joinable!(local_site_rate_limit -> local_site (local_site_id));
 joinable!(tagline -> local_site (local_site_id));
+joinable!(custom_emoji -> local_site (local_site_id));
+joinable!(custom_emoji_keyword -> custom_emoji (custom_emoji_id));
 
 allow_tables_to_appear_in_same_query!(
   activity,
@@ -887,5 +910,7 @@ allow_tables_to_appear_in_same_query!(
   federation_blocklist,
   local_site,
   local_site_rate_limit,
-  person_follower
+  person_follower,
+  custom_emoji,
+  custom_emoji_keyword,
 );

--- a/crates/db_schema/src/source/custom_emoji.rs
+++ b/crates/db_schema/src/source/custom_emoji.rs
@@ -1,0 +1,44 @@
+use crate::newtypes::{DbUrl, LocalSiteId};
+#[cfg(feature = "full")]
+use crate::schema::custom_emoji;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]
+#[cfg_attr(feature = "full", diesel(table_name = custom_emoji))]
+#[cfg_attr(
+  feature = "full",
+  diesel(belongs_to(crate::source::local_site::LocalSite))
+)]
+pub struct CustomEmoji {
+  pub id: i32,
+  pub local_site_id: LocalSiteId,
+  pub shortcode: String,
+  pub image_url: DbUrl,
+  pub alt_text: String,
+  pub category: String,
+  pub published: chrono::NaiveDateTime,
+  pub updated: Option<chrono::NaiveDateTime>,
+}
+
+#[derive(Debug, Clone, TypedBuilder)]
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = custom_emoji))]
+pub struct CustomEmojiInsertForm {
+  pub local_site_id: LocalSiteId,
+  pub shortcode: String,
+  pub image_url: DbUrl,
+  pub alt_text: String,
+  pub category: String,
+}
+
+#[derive(Debug, Clone, TypedBuilder)]
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = custom_emoji))]
+pub struct CustomEmojiUpdateForm {
+  pub local_site_id: LocalSiteId,
+  pub image_url: DbUrl,
+  pub alt_text: String,
+  pub category: String,
+}

--- a/crates/db_schema/src/source/custom_emoji_keyword.rs
+++ b/crates/db_schema/src/source/custom_emoji_keyword.rs
@@ -1,0 +1,25 @@
+#[cfg(feature = "full")]
+use crate::schema::custom_emoji_keyword;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "full", derive(Queryable, Associations, Identifiable))]
+#[cfg_attr(feature = "full", diesel(table_name = custom_emoji_keyword))]
+#[cfg_attr(
+  feature = "full",
+  diesel(belongs_to(crate::source::custom_emoji::CustomEmoji))
+)]
+pub struct CustomEmojiKeyword {
+  pub id: i32,
+  pub custom_emoji_id: i32,
+  pub keyword: String,
+}
+
+#[derive(Debug, Clone, TypedBuilder)]
+#[cfg_attr(feature = "full", derive(Insertable, AsChangeset))]
+#[cfg_attr(feature = "full", diesel(table_name = custom_emoji_keyword))]
+pub struct CustomEmojiKeywordInsertForm {
+  pub custom_emoji_id: i32,
+  pub keyword: String,
+}

--- a/crates/db_schema/src/source/mod.rs
+++ b/crates/db_schema/src/source/mod.rs
@@ -6,6 +6,8 @@ pub mod comment_reply;
 pub mod comment_report;
 pub mod community;
 pub mod community_block;
+pub mod custom_emoji;
+pub mod custom_emoji_keyword;
 pub mod email_verification;
 pub mod federation_allowlist;
 pub mod federation_blocklist;

--- a/crates/db_views/src/custom_emoji_view.rs
+++ b/crates/db_views/src/custom_emoji_view.rs
@@ -1,0 +1,56 @@
+use crate::structs::CustomEmojiView;
+use diesel::{result::Error, BelongingToDsl, ExpressionMethods, GroupedBy, QueryDsl};
+use diesel_async::RunQueryDsl;
+use lemmy_db_schema::{
+  newtypes::LocalSiteId,
+  schema::custom_emoji::{
+    dsl::{custom_emoji, local_site_id},
+    id,
+  },
+  source::{custom_emoji::CustomEmoji, custom_emoji_keyword::CustomEmojiKeyword},
+  utils::{get_conn, DbPool},
+};
+
+impl CustomEmojiView {
+  pub async fn get(pool: &DbPool, emoji_id: i32) -> Result<Self, Error> {
+    let conn = &mut get_conn(pool).await?;
+    let emoji = custom_emoji
+      .find(emoji_id)
+      .first::<CustomEmoji>(conn)
+      .await?;
+    let keywords = CustomEmojiKeyword::belonging_to(&emoji)
+      .load::<CustomEmojiKeyword>(conn)
+      .await?;
+
+    let view = CustomEmojiView {
+      custom_emoji: emoji,
+      keywords,
+    };
+
+    Ok(view)
+  }
+
+  pub async fn get_all(pool: &DbPool, for_local_site_id: LocalSiteId) -> Result<Vec<Self>, Error> {
+    let conn = &mut get_conn(pool).await?;
+    let emojis = custom_emoji
+      .filter(local_site_id.eq(for_local_site_id))
+      .order(id.asc())
+      .load::<CustomEmoji>(conn)
+      .await?;
+    let keywords = CustomEmojiKeyword::belonging_to(&emojis)
+      .load::<CustomEmojiKeyword>(conn)
+      .await?
+      .grouped_by(&emojis);
+
+    let views = emojis
+      .into_iter()
+      .zip(keywords)
+      .map(|x| CustomEmojiView {
+        custom_emoji: x.0,
+        keywords: x.1,
+      })
+      .collect::<Vec<_>>();
+
+    Ok(views)
+  }
+}

--- a/crates/db_views/src/lib.rs
+++ b/crates/db_views/src/lib.rs
@@ -6,6 +6,8 @@ pub mod comment_report_view;
 #[cfg(feature = "full")]
 pub mod comment_view;
 #[cfg(feature = "full")]
+pub mod custom_emoji_view;
+#[cfg(feature = "full")]
 pub mod local_user_view;
 #[cfg(feature = "full")]
 pub mod post_report_view;

--- a/crates/db_views/src/structs.rs
+++ b/crates/db_views/src/structs.rs
@@ -4,6 +4,8 @@ use lemmy_db_schema::{
     comment::Comment,
     comment_report::CommentReport,
     community::CommunitySafe,
+    custom_emoji::CustomEmoji,
+    custom_emoji_keyword::CustomEmojiKeyword,
     local_site::LocalSite,
     local_site_rate_limit::LocalSiteRateLimit,
     local_user::{LocalUser, LocalUserSettings},
@@ -119,4 +121,9 @@ pub struct SiteView {
   pub local_site: LocalSite,
   pub local_site_rate_limit: LocalSiteRateLimit,
   pub counts: SiteAggregates,
+}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CustomEmojiView {
+  pub custom_emoji: CustomEmoji,
+  pub keywords: Vec<CustomEmojiKeyword>,
 }

--- a/migrations/2022-11-27-180447_custom_emojis/down.sql
+++ b/migrations/2022-11-27-180447_custom_emojis/down.sql
@@ -1,0 +1,2 @@
+drop table custom_emoji_keyword;
+drop table custom_emoji;

--- a/migrations/2022-11-27-180447_custom_emojis/up.sql
+++ b/migrations/2022-11-27-180447_custom_emojis/up.sql
@@ -1,0 +1,16 @@
+create table custom_emoji (
+  id serial primary key,
+  local_site_id int references local_site on update cascade on delete cascade not null,
+  shortcode varchar(128) not null UNIQUE,
+  image_url text not null UNIQUE,
+  alt_text text not null,
+  category text not null,
+  published timestamp without time zone default now() not null,
+  updated timestamp without time zone
+);
+
+create table custom_emoji_keyword (
+  id serial primary key,
+  custom_emoji_id int references custom_emoji on update cascade on delete cascade not null,
+  keyword varchar(128) not null
+);

--- a/src/api_routes_http.rs
+++ b/src/api_routes_http.rs
@@ -30,6 +30,7 @@ use lemmy_api_common::{
     TransferCommunity,
   },
   context::LemmyContext,
+  custom_emoji::{CreateCustomEmoji, DeleteCustomEmoji, EditCustomEmoji},
   person::{
     AddAdmin,
     BanPerson,
@@ -347,6 +348,16 @@ pub fn config(cfg: &mut web::ServiceConfig, rate_limit: &RateLimitCell) {
           .route("/community", web::post().to(route_post::<PurgeCommunity>))
           .route("/post", web::post().to(route_post::<PurgePost>))
           .route("/comment", web::post().to(route_post::<PurgeComment>)),
+      )
+      .service(
+        web::scope("/custom_emoji")
+          .wrap(rate_limit.message())
+          .route("", web::post().to(route_post_crud::<CreateCustomEmoji>))
+          .route("", web::put().to(route_post_crud::<EditCustomEmoji>))
+          .route(
+            "/delete",
+            web::post().to(route_post_crud::<DeleteCustomEmoji>),
+          ),
       ),
   );
 }

--- a/src/api_routes_websocket.rs
+++ b/src/api_routes_websocket.rs
@@ -31,6 +31,7 @@ use lemmy_api_common::{
     TransferCommunity,
   },
   context::LemmyContext,
+  custom_emoji::{CreateCustomEmoji, DeleteCustomEmoji, EditCustomEmoji},
   person::{
     AddAdmin,
     BanPerson,
@@ -379,6 +380,16 @@ pub async fn match_websocket_operation_crud(
     }
     UserOperationCrud::GetComment => {
       do_websocket_operation_crud::<GetComment>(context, id, op, data).await
+    }
+    // Emojis
+    UserOperationCrud::CreateCustomEmoji => {
+      do_websocket_operation_crud::<CreateCustomEmoji>(context, id, op, data).await
+    }
+    UserOperationCrud::EditCustomEmoji => {
+      do_websocket_operation_crud::<EditCustomEmoji>(context, id, op, data).await
+    }
+    UserOperationCrud::DeleteCustomEmoji => {
+      do_websocket_operation_crud::<DeleteCustomEmoji>(context, id, op, data).await
     }
   }
 }


### PR DESCRIPTION
These are the main changes necessary to make emojis in posts and comments federate. You just need to add code where i left TODO comments, to read/write the used emojis to the database. If emojis should work in other object types like private message, and community, site, person (for sidebar/bio), you need to make the same changes there as well.